### PR TITLE
correct import of port back to Spark instead of SparkBase

### DIFF
--- a/src/main/java/com/swisscom/cloud/cloudfoundry/sampleapp/java/ProductService.java
+++ b/src/main/java/com/swisscom/cloud/cloudfoundry/sampleapp/java/ProductService.java
@@ -2,7 +2,7 @@ package com.swisscom.cloud.cloudfoundry.sampleapp.java;
 
 import static spark.Spark.get;
 import static spark.Spark.post;
-import static spark.SparkBase.port;
+import static spark.Spark.port;
 
 import java.io.IOException;
 import java.io.StringWriter;


### PR DESCRIPTION
`import static spark.SparkBase.port` is breaking the gradle build. Reverted to `import static spark.Spark.port`.